### PR TITLE
Switch to sf archive to get v2.x

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,7 +25,7 @@ source $BP_DIR/lib/stdlib.sh
 
 install_sfdx_cli() {
   log "Downloading Salesforce CLI tarball ..."
-  mkdir sfdx && curl --silent --location "https://developer.salesforce.com/media/salesforce-cli/sfdx/channels/stable/sfdx-linux-x64.tar.xz" | tar xJ -C sfdx --strip-components 1
+  mkdir sfdx && curl --silent --location "https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-linux-x64.tar.xz" | tar xJ -C sfdx --strip-components 1
 
   log "Copying Salesforce CLI binary ..."
 


### PR DESCRIPTION
This buildpack currently installs `sf` version `1.86.7-legacy.0`, which is is way behind current version `2.14.6`.

This PR updates to use the new download URL as listed in [Developer docs](https://developer.salesforce.com/docs/atlas.en-us.sfdx_setup.meta/sfdx_setup/sfdx_setup_install_cli.htm).

[#platform-cli Slack conversation](https://salesforce-internal.slack.com/archives/C01LKDT1P6J/p1698693960139809).