### PR TITLE
Added jq to $PATH in the generated .profile.d/salesforce_cli_path.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,4 @@ This is the official [Heroku buildpack](http://devcenter.heroku.com/articles/bui
 
 ## Usage
 
-To use `sfdx` and `jq`, you simply need to export the appropriate paths:
-
-```
-export PATH="$BUILD_DIR/vendor/sfdx/cli/bin:$PATH"
-export PATH="$BUILD_DIR/vendor/sfdx/jq:$PATH"
-```
-
-The `$BUILD_DIR` is the path where your apps source is stored on the Heroku dyno.
+The `sfdx` and `jq` commands are automatically added to $PATH during the startup of each Heroku process.

--- a/bin/compile
+++ b/bin/compile
@@ -73,7 +73,9 @@ mkdir -p $BUILD_DIR/.profile.d
 if [ ! -f $BUILD_DIR/.profile.d/path.sh ]; then
   log "Creating path.sh ..."
   echo "echo \"Updating PATH to include Salesforce CLI ...\"
-export PATH=\$PATH:/app/vendor/sfdx/cli/bin/" > $BUILD_DIR/.profile.d/path.sh
+export PATH=\$PATH:/app/vendor/sfdx/cli/bin
+export PATH=\$PATH:/app/vendor/sfdx/jq
+" > $BUILD_DIR/.profile.d/path.sh
 
   log "Generated $BUILD_DIR/.profile.d/path.sh to add CLI path"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -69,13 +69,13 @@ install_jq
 # Create .profile.d folder
 mkdir -p $BUILD_DIR/.profile.d
 
-# if no .profile.d/path.sh, create one
-if [ ! -f $BUILD_DIR/.profile.d/path.sh ]; then
-  log "Creating path.sh ..."
+# if no .profile.d/salesforce_cli_path.sh, create one
+if [ ! -f $BUILD_DIR/.profile.d/salesforce_cli_path.sh ]; then
+  log "Creating salesforce_cli_path.sh ..."
   echo "echo \"Updating PATH to include Salesforce CLI ...\"
-export PATH=\$PATH:/app/vendor/sfdx/cli/bin/" > $BUILD_DIR/.profile.d/path.sh
+export PATH=\$PATH:/app/vendor/sfdx/cli/bin/" > $BUILD_DIR/.profile.d/salesforce_cli_path.sh
 
-  log "Generated $BUILD_DIR/.profile.d/path.sh to add CLI path"
+  log "Generated $BUILD_DIR/.profile.d/salesforce_cli_path.sh to add CLI path"
 fi
 
 header "DONE! Completed in $(($SECONDS - $START_TIME))s"

--- a/bin/compile
+++ b/bin/compile
@@ -69,15 +69,15 @@ install_jq
 # Create .profile.d folder
 mkdir -p $BUILD_DIR/.profile.d
 
-# if no .profile.d/path.sh, create one
-if [ ! -f $BUILD_DIR/.profile.d/path.sh ]; then
-  log "Creating path.sh ..."
-  echo "echo \"Updating PATH to include Salesforce CLI ...\"
+# if no .profile.d/salesforce_cli_path.sh, create one
+ if [ ! -f $BUILD_DIR/.profile.d/salesforce_cli_path.sh ]; then
+   log "Creating salesforce_cli_path.sh ..."
+   echo "echo \"Updating PATH to include Salesforce CLI and jq ...\"
 export PATH=\$PATH:/app/vendor/sfdx/cli/bin
 export PATH=\$PATH:/app/vendor/sfdx/jq
-" > $BUILD_DIR/.profile.d/path.sh
+" > $BUILD_DIR/.profile.d/salesforce_cli_path.sh
 
-  log "Generated $BUILD_DIR/.profile.d/path.sh to add CLI path"
+   log "Generated $BUILD_DIR/.profile.d/salesforce_cli_path.sh to add CLI path"
 fi
 
 header "DONE! Completed in $(($SECONDS - $START_TIME))s"

--- a/bin/compile
+++ b/bin/compile
@@ -23,6 +23,10 @@ source $BP_DIR/lib/stdlib.sh
 
 ### Setup functions
 
+update_npm() {
+  npm -nstall -g npm@10.5.2
+}
+
 install_sfdx_cli() {
   log "Downloading Salesforce CLI tarball ..."
   mkdir sfdx && curl --silent --location "https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-linux-x64.tar.xz" | tar xJ -C sfdx --strip-components 1
@@ -43,6 +47,8 @@ install_jq() {
   cd "$BUILD_DIR/vendor/sfdx/jq"
   wget --quiet -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
   chmod +x jq
+
+jq --version
 }
 
 setup_dirs() {
@@ -62,6 +68,9 @@ debug "ENV_DIR: $ENV_DIR"
 debug "BP_DIR: $BP_DIR"
 
 setup_dirs
+
+update_npm
+
 log "Starting CLI installation ..."
 install_sfdx_cli
 

--- a/bin/compile
+++ b/bin/compile
@@ -33,6 +33,8 @@ install_sfdx_cli() {
   mkdir -p "$BUILD_DIR/vendor/sfdx"
   cp -r sfdx "$BUILD_DIR/vendor/sfdx/cli"
   chmod -R 755  "$BUILD_DIR/vendor/sfdx/cli"
+
+  sf version --verbose
 }
 
 install_jq() {

--- a/bin/compile
+++ b/bin/compile
@@ -23,10 +23,6 @@ source $BP_DIR/lib/stdlib.sh
 
 ### Setup functions
 
-update_npm() {
-  npm install -g npm@10.5.2
-}
-
 install_sfdx_cli() {
   log "Downloading Salesforce CLI tarball ..."
   mkdir sfdx && curl --silent --location "https://developer.salesforce.com/media/salesforce-cli/sf/channels/stable/sf-linux-x64.tar.xz" | tar xJ -C sfdx --strip-components 1
@@ -45,10 +41,10 @@ install_jq() {
   log "Downloading jq ..."
   mkdir -p "$BUILD_DIR/vendor/sfdx/jq"
   cd "$BUILD_DIR/vendor/sfdx/jq"
-  wget --quiet -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+  wget --quiet -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
   chmod +x jq
 
-jq --version
+  jq --version
 }
 
 setup_dirs() {
@@ -68,8 +64,6 @@ debug "ENV_DIR: $ENV_DIR"
 debug "BP_DIR: $BP_DIR"
 
 setup_dirs
-
-update_npm
 
 log "Starting CLI installation ..."
 install_sfdx_cli

--- a/bin/compile
+++ b/bin/compile
@@ -24,7 +24,7 @@ source $BP_DIR/lib/stdlib.sh
 ### Setup functions
 
 update_npm() {
-  npm -nstall -g npm@10.5.2
+  npm install -g npm@10.5.2
 }
 
 install_sfdx_cli() {


### PR DESCRIPTION
Fixes #12

- [x] added jq to the $PATH generated in the .profile.d/salesforce_cli_path.sh file
- [x] changed the 'Usage' chapter of the README to reflect that $PATH is automatically updated during the startup of each Heroku process